### PR TITLE
fix #2 Remove the job id from the running job list when the job is done executing

### DIFF
--- a/biz.go
+++ b/biz.go
@@ -68,6 +68,10 @@ func (biz *ExecutorBiz) Run(ctx *server.Context) {
 			}
 		}()
 
+		defer func() {
+			job.GetRunningJobList().Del(utils.Int2Str(jobHandler.Id))
+		}()
+
 		var resp job.Resp
 		defer func() {
 			var call []admin.HandleCallbackParams


### PR DESCRIPTION
fix #2 Remove the job id from the running job list when the job is done executing